### PR TITLE
[PHP-XRAY] Update php-stan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.0.0",
-    "phpstan/phpstan": "^1.0.0",
+    "phpstan/phpstan": "1.5.*",
     "phpstan/extension-installer": "^1.0.0",
     "phpstan/phpstan-deprecation-rules": "^1.0.0",
     "phpstan/phpstan-php-parser": "^1.0.0",


### PR DESCRIPTION
 - EDIT: update composer.json with last known php-stan fixed version

Set fixed version (1.5.*) to be a bit more restrictive because there was already set the caret version (^1.0.0) that automatically chose the latest available version (1.5.3)